### PR TITLE
Fixed "TouchableHighlight onPress = Black background", Added firstItem prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Well-done.
 | resizeMode                   | string                                | default is `cover`                                                                                                                                      |
 | ImageComponentStyle          | object                                | {} style object for ImageComponent   |
 | imageLoadingColor            | string                                | default is `#E91E63` , image loading indicator color       |
+| defaultStartIndex            | number                                | default is 0 , index of image to display when slider box loads       |
 
 ### 1- add below import in your code :
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Well-done.
 | resizeMode                   | string                                | default is `cover`                                                                                                                                      |
 | ImageComponentStyle          | object                                | {} style object for ImageComponent   |
 | imageLoadingColor            | string                                | default is `#E91E63` , image loading indicator color       |
-| defaultStartIndex            | number                                | default is 0 , index of image to display when slider box loads       |
+| firstItem            | number                                | default is 0 , index of image to display when slider box loads       |
 
 ### 1- add below import in your code :
 

--- a/dist/SliderBox.js
+++ b/dist/SliderBox.js
@@ -27,7 +27,7 @@ import styles from "./SliderBox.style";
 // resizeMode
 // ImageComponentStyle,
 // imageLoadingColor = "#E91E63"
-// defaultStartIndex = 0
+// firstItem = 0
 
 const width = Dimensions.get("window").width;
 
@@ -35,7 +35,7 @@ export class SliderBox extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      currentImage: props.defaultStartIndex || 0,
+      currentImage: props.firstItem || 0,
       loading: []
     };
     this.onCurrentImagePressedHandler = this.onCurrentImagePressedHandler.bind(

--- a/dist/SliderBox.js
+++ b/dist/SliderBox.js
@@ -27,6 +27,7 @@ import styles from "./SliderBox.style";
 // resizeMode
 // ImageComponentStyle,
 // imageLoadingColor = "#E91E63"
+// defaultStartIndex = 0
 
 const width = Dimensions.get("window").width;
 
@@ -34,7 +35,7 @@ export class SliderBox extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      currentImage: 0,
+      currentImage: props.defaultStartIndex || 0,
       loading: []
     };
     this.onCurrentImagePressedHandler = this.onCurrentImagePressedHandler.bind(

--- a/dist/SliderBox.js
+++ b/dist/SliderBox.js
@@ -79,7 +79,7 @@ export class SliderBox extends Component {
           key={index}
           disabled={disableOnPress}
           onPress={this.onCurrentImagePressedHandler}
-          underlayColor={'transparent'}
+          underlayColor={'none'}
         >
           <ImageComponent
             style={[

--- a/dist/SliderBox.js
+++ b/dist/SliderBox.js
@@ -3,7 +3,7 @@ import {
   View,
   Image,
   ActivityIndicator,
-  TouchableHighlight,
+  TouchableOpacity,
   Dimensions
 } from "react-native";
 
@@ -75,11 +75,11 @@ export class SliderBox extends Component {
           justifyContent: "center"
         }}
       >
-        <TouchableHighlight
+        <TouchableOpacity
           key={index}
           disabled={disableOnPress}
           onPress={this.onCurrentImagePressedHandler}
-          underlayColor={'none'}
+          activeOpacity={1}
         >
           <ImageComponent
             style={[
@@ -102,7 +102,7 @@ export class SliderBox extends Component {
             }}
             {...this.props}
           />
-        </TouchableHighlight>
+        </TouchableOpacity>
         {!this.state.loading[index] && (
           <ActivityIndicator
             size="large"


### PR DESCRIPTION
This is to address [issue #49](https://github.com/intellidev1991/react-native-image-slider-box/issues/49). I tried using underlayColor={'none'} as suggested in the issue, but that didn't seem to work and I still saw the black highlight. Doing it this way resolved the issue on my end.

Also added a prop to address an issue I needed solved- firstItem is a prop that can be used to specify an initial image to show when the sliderbox loads.