### PR TITLE
when add useScrollView the image loading on ios/android fixed

### DIFF
--- a/dist/SliderBox.js
+++ b/dist/SliderBox.js
@@ -165,6 +165,7 @@ export class SliderBox extends Component {
         <Carousel
           autoplayDelay={autoplayDelay}
           layout={"default"}
+          useScrollView
           data={images}
           ref={c => (this._ref = c)}
           loop={circleLoop || false}


### PR DESCRIPTION
The solution of issue #22  is to pass 'useScrollView' prop to fix this issue i figure-out after debugging this prop is from react-native-snap-carousel which this component uses heavily.